### PR TITLE
Build docker-image with fresh ivy2 cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,15 @@ This docker image is set up in order to run the tests for Dotty. It is
 currently pushed to [lampepfl/dotty](https://hub.docker.com/r/lampepfl/dotty/)
 on Docker hub.
 
-To update the image, simply:
+To build the image, simply:
 
 ```
-$ tar -zxvf ivy2.tar.gz
+$ cd docker
 $ sudo su
 # docker build --no-cache -t lampepfl/dotty .
 <some-tag-hash-here>
-# docker push lampepfl/dotty:latest
-# docker tag <some-tag-hash-here> lampepfl/dotty:0.2
-# docker push lampepfl/dotty:0.2
+# docker tag <some-tag-hash-here> lampepfl/dotty:01-01-2020
+# docker push lampepfl/dotty:01-01-2020
 ```
 
 Currently the cache is r/w by all users of the image - which should be defined

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use alpine as base for Docker image
-FROM alpine:3.4
+FROM alpine:3.5
 
 # Add necessary packages to image:
 RUN apk add --update git && \
@@ -25,7 +25,10 @@ WORKDIR /var/cache/drone
 RUN git clone --depth 1 -b dotty-library https://github.com/DarkDimius/scala.git scala-scala
 
 # Add ivy2 cache
-COPY ivy2/ ivy2
+RUN git clone --recursive --depth 1 https://github.com/lampepfl/dotty.git dotty
+RUN bash -c 'cd dotty; sbt ";compile ;test:compile"'
+RUN rm -rf dotty
+RUN mv ~/.ivy2 /var/cache/drone/ivy2
 
 # Make cache rw by all users (drone adds user 'drone', doesn't exist yet)
 RUN chmod -R 0777 /var/cache/drone/ivy2

--- a/docker/ivy2.tar.gz
+++ b/docker/ivy2.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:317b37c11444c96640863e1eb1dc45ed33129b35a8bdab23acfb808bc73a74e7
-size 138704993


### PR DESCRIPTION
@felixmulder if this is merged, we could rewrite history to remove the `ivy2.tar.gz` binary, the repo would get back to a reasonable size.