### PR TITLE
Set the number of parallel builds

### DIFF
--- a/drone/docker-compose.yml
+++ b/drone/docker-compose.yml
@@ -28,6 +28,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - DRONE_TIMEOUT=10m
-      - DRONE_MAX_PROCS=8
+      - DRONE_MAX_PROCS=4
       - DRONE_SERVER=drone-server:9000
       - DRONE_SECRET=<server/agent secret here>


### PR DESCRIPTION
With matrices, the number of parallel build was `DRONE_MAX_PROCS / nb_of_entries_in_matrix`.
Now that we don't use matrices anymore, I believe the number of parallel builds is simply `DRONE_MAX_PROCS`.

[discourse post for reference](https://discourse.drone.io/t/distinct-workspace-for-parallel-build-steps/604/4?u=allanrenucci)