### PR TITLE
Add Node.js to the installed packages.

### DIFF
--- a/dotty-docker/Dockerfile
+++ b/dotty-docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     # Enable pre-release openjdk 11, remove the next line once openjdk 11 has been released and Ubuntu updates its package.
     apt-get install -y software-properties-common && add-apt-repository ppa:openjdk-r/ppa && \
-    apt-get install -y bash curl git ssh htop openjdk-8-jdk-headless openjdk-11-jdk-headless nano vim-tiny zile && \
+    apt-get install -y bash curl git ssh htop openjdk-8-jdk-headless openjdk-11-jdk-headless nano vim-tiny zile nodejs-legacy && \
     update-java-alternatives --set java-1.8.0-openjdk-amd64
 
 # Set sbt env variables


### PR DESCRIPTION
We use the package `nodejs-legacy` rather than `nodejs` so that there is an executable called `node`, as expected by default.