### PR TITLE
chore: various updates

### DIFF
--- a/dotty-docker/Dockerfile
+++ b/dotty-docker/Dockerfile
@@ -19,5 +19,5 @@ RUN apt-get update && \
 # Install sbt
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${SBT_HOME}/bin:${PATH}
-ENV SBT_VERSION 1.8.3
+ENV SBT_VERSION 1.9.0
 RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local

--- a/dotty-docker/Dockerfile
+++ b/dotty-docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # The default locale is "POSIX" which is just ASCII.
 ENV LANG C.UTF-8
-env DEBIAN_FRONTEND noninteractive
-env TZ Europe/Zurich
+ENV DEBIAN_FRONTEND noninteractive
+ENV TZ Europe/Zurich
 
 # Add packages to image, set default JDK version
 RUN apt-get update && \
@@ -12,14 +12,12 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && add-apt-repository ppa:openjdk-r/ppa && \
     apt-get install -y bash curl git ssh htop openjdk-8-jdk-headless openjdk-17-jdk-headless \
                        nano vim-tiny zile && \
-    # Ubuntu 20.04 has Node 10 but Scala.js tests require >= 14 (cf https://github.com/lampepfl/dotty/pull/11818)
-    (curl -fsSL https://deb.nodesource.com/setup_14.x | bash -) && \
-    apt-get install -y nodejs && \
-    update-java-alternatives --set java-1.8.0-openjdk-amd64
+    (curl -fsSL https://deb.nodesource.com/setup_18.x | bash -) && \
+    apt-get install -y nodejs
 
 
 # Install sbt
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${SBT_HOME}/bin:${PATH}
-ENV SBT_VERSION 1.5.5
+ENV SBT_VERSION 1.8.3
 RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local


### PR DESCRIPTION
This updates the following:

- base ubuntu image to 22.04
- Node to 18
- Stops setting the default jdk to 8
- updates sbt to ~1.8.3~ 1.9.0

refs: https://github.com/lampepfl/dotty/discussions/17630
