### PR TITLE
Install Java 21

### DIFF
--- a/dotty-docker/Dockerfile
+++ b/dotty-docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     # Use a PPA to get Java 17
     apt-get install -y software-properties-common && add-apt-repository ppa:openjdk-r/ppa && \
     apt-get install -y bash curl git ssh htop openjdk-8-jdk-headless openjdk-17-jdk-headless \
-                       nano vim-tiny zile && \
+                       openjdk-21-jdk-headless nano vim-tiny zile && \
     (curl -fsSL https://deb.nodesource.com/setup_18.x | bash -) && \
     apt-get install -y nodejs
 


### PR DESCRIPTION
Java 21 will be required for https://github.com/lampepfl/dotty/issues/18584, https://github.com/lampepfl/dotty/pull/18790

Testing:

```
docker build  -t lampepfl/dotty:$(date +%F) .
docker run lampepfl/dotty:2023-11-04 /usr/lib/jvm/java-21-openjdk-arm64/bin/java -version
```